### PR TITLE
Fix #1: 拖拽排序持久化到数据库（v2）

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,5 +11,6 @@ model Task {
   id        String   @id @default(cuid())
   title     String
   status    String   @default("todo")
+  position  Int      @default(0)
   createdAt DateTime @default(now())
 }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,32 +1,47 @@
 import { prisma } from "@/lib/prisma";
 import { NextResponse } from "next/server";
 
-// PATCH /api/tasks/[id] - 只能更新status，不能更新position！
+// PATCH /api/tasks/[id] - 支持更新 status 和/或 position
 export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
   const body = await request.json();
-  const { status } = body;
+  const { status, position } = body;
 
-  if (!status) {
+  if (status === undefined && position === undefined) {
     return NextResponse.json(
-      { error: "必须提供status字段" },
+      { error: "必须提供 status 或 position 字段" },
       { status: 400 }
     );
   }
 
-  const validStatuses = ["todo", "inprogress", "done"];
-  if (!validStatuses.includes(status)) {
-    return NextResponse.json(
-      { error: "无效的status值" },
-      { status: 400 }
-    );
+  const data: { status?: string; position?: number } = {};
+
+  if (status !== undefined) {
+    const validStatuses = ["todo", "inprogress", "done"];
+    if (!validStatuses.includes(status)) {
+      return NextResponse.json(
+        { error: "无效的 status 值" },
+        { status: 400 }
+      );
+    }
+    data.status = status;
+  }
+
+  if (position !== undefined) {
+    if (typeof position !== "number") {
+      return NextResponse.json(
+        { error: "position 必须是数字" },
+        { status: 400 }
+      );
+    }
+    data.position = position;
   }
 
   const task = await prisma.task.update({
     where: { id: params.id },
-    data: { status },
+    data,
   });
 
   return NextResponse.json(task);

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,15 +1,15 @@
 import { prisma } from "@/lib/prisma";
 import { NextResponse } from "next/server";
 
-// GET /api/tasks - 获取所有任务，按创建时间倒序
+// GET /api/tasks - 获取所有任务，按 position 升序
 export async function GET() {
   const tasks = await prisma.task.findMany({
-    orderBy: { createdAt: "desc" },
+    orderBy: { position: "asc" },
   });
   return NextResponse.json(tasks);
 }
 
-// POST /api/tasks - 创建新任务
+// POST /api/tasks - 创建新任务，position 默认为该列最大 + 1
 export async function POST(request: Request) {
   const body = await request.json();
   const { title, status } = body;
@@ -18,10 +18,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "标题不能为空" }, { status: 400 });
   }
 
+  const targetStatus = status || "todo";
+
+  // 查询该列当前最大 position
+  const lastTask = await prisma.task.findFirst({
+    where: { status: targetStatus },
+    orderBy: { position: "desc" },
+  });
+  const nextPosition = (lastTask?.position ?? -1) + 1;
+
   const task = await prisma.task.create({
     data: {
       title: title.trim(),
-      status: status || "todo",
+      status: targetStatus,
+      position: nextPosition,
     },
   });
 

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { DragDropContext, Droppable, DropResult } from "react-beautiful-dnd";
 import Column from "./Column";
 import NewTaskModal from "./NewTaskModal";
@@ -9,6 +9,7 @@ export interface Task {
   id: string;
   title: string;
   status: string;
+  position: number;
   createdAt: string;
 }
 
@@ -23,11 +24,18 @@ export default function Board() {
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalStatus, setModalStatus] = useState("todo");
+  const tasksBeforeDrag = useRef<Task[]>([]);
 
   const fetchTasks = useCallback(async () => {
     const res = await fetch("/api/tasks");
     const data = await res.json();
-    // 从数据库加载，按createdAt倒序
+    // 兼容：migrate 后旧数据 position 全为 0，按 createdAt 倒序保底
+    if (data.length > 0 && data.every((t: Task) => t.position === 0)) {
+      data.sort(
+        (a: Task, b: Task) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+    }
     setTasks(data);
     setLoading(false);
   }, []);
@@ -42,17 +50,15 @@ export default function Board() {
 
   const onDragStart = () => {
     document.body.classList.add("rfd-dragging");
+    tasksBeforeDrag.current = [...tasks];
   };
 
-  // 关键：onDragEnd 只更新前端 state，不保存顺序到后端！
-  const onDragEnd = (result: DropResult) => {
+  // 拖拽结束后计算各列 position 并批量 PATCH
+  const onDragEnd = async (result: DropResult) => {
     document.body.classList.remove("rfd-dragging");
     const { destination, source, draggableId } = result;
 
-    // 没有目标位置，不做任何处理
     if (!destination) return;
-
-    // 拖回原位置
     if (
       destination.droppableId === source.droppableId &&
       destination.index === source.index
@@ -60,52 +66,79 @@ export default function Board() {
       return;
     }
 
-    const taskId = draggableId;
-    const newStatus = destination.droppableId;
+    // ── 1. 乐观更新本地 state ──
+    let nextTasks: Task[];
 
-    // 跨列拖拽：更新 status（保存到后端）
     if (source.droppableId !== destination.droppableId) {
-      // 先在本地更新
-      setTasks((prev) => {
-        const updated = prev.map((t) =>
-          t.id === taskId ? { ...t, status: newStatus } : t
-        );
-        // 把拖拽的任务放到目标列的最后
-        const sourceTasks = updated.filter((t) => t.status === source.droppableId);
-        const destTasks = updated.filter((t) => t.status === newStatus);
-        const draggedTask = updated.find((t) => t.id === taskId)!;
-        const otherTasks = updated.filter((t) => t.id !== taskId);
-
-        // 重建目标列的顺序：拖拽的卡片在最后
-        const newDestTasks = destTasks.filter((t) => t.id !== taskId);
-        newDestTasks.push(draggedTask);
-
-        return [
-          ...otherTasks.filter((t) => t.status !== newStatus),
-          ...sourceTasks,
-          ...newDestTasks,
-        ];
-      });
-
-      // 调用后端API更新status（注意：只更新status，不保存position！）
-      fetch(`/api/tasks/${taskId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: newStatus }),
-      });
+      // 跨列：先改 status，再插到目标列的 destination.index
+      nextTasks = tasks.map((t) =>
+        t.id === draggableId ? { ...t, status: destination.droppableId } : t
+      );
+      const destCol = nextTasks.filter((t) => t.status === destination.droppableId);
+      const otherCols = nextTasks.filter((t) => t.status !== destination.droppableId);
+      const moved = destCol.find((t) => t.id === draggableId)!;
+      const destOthers = destCol.filter((t) => t.id !== draggableId);
+      destOthers.splice(destination.index, 0, moved);
+      nextTasks = [...otherCols, ...destOthers];
     } else {
-      // 同列内拖拽：只更新前端 state，不调用后端！
-      // 这就是 bug 所在：排序只在前端生效，刷新就恢复
-      setTasks((prev) => {
-        const columnTasks = prev.filter((t) => t.status === newStatus);
-        const otherTasks = prev.filter((t) => t.status !== newStatus);
+      // 同列：reorder
+      const col = tasks.filter((t) => t.status === source.droppableId);
+      const other = tasks.filter((t) => t.status !== source.droppableId);
+      const idx = col.findIndex((t) => t.id === draggableId);
+      const [moved] = col.splice(idx, 1);
+      col.splice(destination.index, 0, moved);
+      nextTasks = [...other, ...col];
+    }
 
-        const draggedIndex = columnTasks.findIndex((t) => t.id === taskId);
-        const [draggedTask] = columnTasks.splice(draggedIndex, 1);
-        columnTasks.splice(destination.index, 0, draggedTask);
+    setTasks(nextTasks);
 
-        return [...otherTasks, ...columnTasks];
-      });
+    // ── 2. 计算需要 PATCH 的变更 ──
+    const byStatus: Record<string, Task[]> = {};
+    for (const t of nextTasks) {
+      if (!byStatus[t.status]) byStatus[t.status] = [];
+      byStatus[t.status].push(t);
+    }
+
+    const patches: { id: string; body: { status?: string; position: number } }[] = [];
+    for (const status of Object.keys(byStatus)) {
+      const col = byStatus[status];
+      for (let i = 0; i < col.length; i++) {
+        const task = col[i];
+        const isMoved = task.id === draggableId;
+        const needStatus = isMoved && source.droppableId !== destination.droppableId;
+        if (task.position !== i || needStatus) {
+          patches.push({
+            id: task.id,
+            body: {
+              ...(needStatus ? { status: destination.droppableId } : {}),
+              position: i,
+            },
+          });
+        }
+      }
+    }
+
+    if (patches.length === 0) return;
+
+    // ── 3. 批量 PATCH，任一失败则回滚 ──
+    try {
+      const results = await Promise.all(
+        patches.map((p) =>
+          fetch(`/api/tasks/${p.id}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(p.body),
+          })
+        )
+      );
+
+      if (!results.every((r) => r.ok)) {
+        throw new Error("Some PATCH requests failed");
+      }
+    } catch (err) {
+      setTasks(tasksBeforeDrag.current);
+      console.error("保存排序失败，已自动回滚", err);
+      // MVP 阶段先用 console.error，后续可接入 toast
     }
   };
 
@@ -120,15 +153,23 @@ export default function Board() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title, status: modalStatus }),
     });
-    const newTask = await res.json();
-    // 新任务加到对应列的最后
-    setTasks((prev) => [...prev, newTask]);
+    if (!res.ok) {
+      console.error("创建任务失败");
+      return;
+    }
+    // 创建成功后重新拉取整列表，保证顺序一致
+    await fetchTasks();
     setModalOpen(false);
   };
 
   const handleDeleteTask = async (id: string) => {
-    await fetch(`/api/tasks/${id}`, { method: "DELETE" });
-    setTasks((prev) => prev.filter((t) => t.id !== id));
+    const res = await fetch(`/api/tasks/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      console.error("删除任务失败");
+      return;
+    }
+    // 删除后重新拉取，避免 position 出现空洞
+    await fetchTasks();
   };
 
   if (loading) {


### PR DESCRIPTION
## 修复内容

修复 **拖拽排序后刷新页面，任务位置回退** 的问题（ISSUE #1）。

### 根因
前后端双双缺失：
1. **前端**：`Board.tsx` 的 `onDragEnd` 同列拖拽分支只更新本地 state，零 API 调用
2. **后端**：`Task` 模型无 `position` 字段；`PATCH` 只接收 `status`；`GET` 按 `createdAt` 排序

### 改动

#### 后端
- `prisma/schema.prisma`：新增 `position Int @default(0)`
- `GET /api/tasks`：改为 `orderBy: { position: 'asc' }`
- `POST /api/tasks`：新任务自动分配 `position = 该列最大值 + 1`
- `PATCH /api/tasks/[id]`：支持 `{status?, position?}` 局部更新

#### 前端
- `onDragEnd`：同列/跨列拖拽后，重新计算该列所有任务的 position，逐个 PATCH 落库
- 乐观更新 + 失败自动回滚，防止「幽灵排序」
- 兼容逻辑：若所有任务 position 均为 0（migrate 后的旧数据），按 `createdAt` 倒序保底
- 创建/删除任务后重新 `fetchTasks()`，避免 position 空洞

### 验证步骤
1. `npx prisma migrate dev`（或 `prisma db push`）应用 schema 变更
2. 拖拽排序任意列内任务 → 刷新页面 → 顺序保持
3. 跨列拖拽任务 → 刷新页面 → 位置保持

---
Fixes #1
